### PR TITLE
Add option to replace hyphens with underscore in tag names

### DIFF
--- a/XmlParser.lua
+++ b/XmlParser.lua
@@ -159,8 +159,12 @@ end
 -- where name is the name of the tag and attrs 
 -- is a table containing the attributes of the tag
 local function parseTag(self, s)
+    local tag_name = string.gsub(s, self._TAG, '%1')
+    if self.options.subHyphens then
+        tag_name = string.gsub(tag_name, '-', '_')
+    end
     local tag = {
-            name = string.gsub(s, self._TAG, '%1'),
+            name = tag_name,
             attrs = {}
           }            
 

--- a/xml2lua.lua
+++ b/xml2lua.lua
@@ -87,6 +87,8 @@ function xml2lua.parser(handler)
     local options = {
             --Indicates if whitespaces should be striped or not
             stripWS = 1,
+            --Should we replace hyphens with underscores in tag names as we parse
+            subHyphens = 0,
             expandEntities = 1,
             errorHandler = function(errMsg, pos)
                 error(string.format("%s [char=%d]\n", errMsg or "Parse Error", pos))


### PR DESCRIPTION
Because Lua uses hyphen as a "magic" character, it makes it difficult to address tree nodes directly if the node name has a hyphen in it so we replace them with underscores as we parse the xml