### PR TITLE
add path to require() since we can't easily modify LUAPATH for FS

### DIFF
--- a/xml2lua.lua
+++ b/xml2lua.lua
@@ -50,7 +50,7 @@
 --@author Paul Chakravarti (paulc@passtheaardvark.com)
 --@author Manoel Campos da Silva Filho
 local xml2lua = { _VERSION = "1.6-1" }
-local XmlParser = require("XmlParser")
+local XmlParser = require("xml2lua.XmlParser")
 
 ---Recursivelly prints a table in an easy-to-ready format
 --@param tb The table to be printed


### PR DESCRIPTION
Not easy to override the lua path with freeswitch embedding Lua so we'll just put it in our require() so we can leave xml2lua in a folder in the modules path for easier git management.